### PR TITLE
25 add backend unit tests usuarios app

### DIFF
--- a/apps/usuarios/tests.py
+++ b/apps/usuarios/tests.py
@@ -49,7 +49,7 @@ class DadoPessoalTestCase(TestCase):
             "cep":"04543-433"}
         DadoPessoal.objects.create(**moc_dado_pessoal_user1)
 
-    def test_doadores_str_(self):
+    def test_dado_pessoal_str_(self):
 
         # pega instância de teste criada no setUp do testCase
         dado_pessoal = DadoPessoal.objects.get(cep='04543-433')

--- a/apps/usuarios/tests.py
+++ b/apps/usuarios/tests.py
@@ -1,3 +1,58 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+from usuarios.models import Estado, DadoPessoal
 
-# Create your tests here.
+class EstadoTestCase(TestCase):
+    def setUp(self):
+
+        # dados moc
+        moc_estado1 = {
+            "sigla":"sp",
+            "estado":"São Paulo",
+            "atende": False}
+        
+        # instância de teste
+        Estado.objects.create(**moc_estado1)
+
+    def test_doadores_str_(self):
+
+        # pega instância de teste criada no setUp do testCase
+        estado = Estado.objects.get(sigla='sp')
+
+        # unit test
+        self.assertEqual(estado.__str__(), 'sp')
+
+class DadoPessoalTestCase(TestCase):
+    def setUp(self):
+
+        # dados moc
+        moc_estado2 = {
+            "sigla":"sp",
+            "estado":"São Paulo",
+            "atende": False}
+
+        # instancia de Estado
+        uf = Estado.objects.create(**moc_estado2)
+
+        # instancia de User
+        user = User.objects.create(username='Fulano')
+    
+        moc_dado_pessoal_user1 = {
+            "usuario":user,
+            "telefone_fixo":"551132136418",
+            "telefone_celular":"5511936187752",
+            "endereco":"rua a",
+            "numero":"34",
+            "complemento":"sdf",
+            "cidade":"sao paulo",
+            "uf":uf,
+            "cep":"04543-433"}
+        DadoPessoal.objects.create(**moc_dado_pessoal_user1)
+
+    def test_doadores_str_(self):
+
+        # pega instância de teste criada no setUp do testCase
+        dado_pessoal = DadoPessoal.objects.get(cep='04543-433')
+
+        # unit test
+        self.assertEqual(str(dado_pessoal.__str__()), 'Fulano')

--- a/elos_be/settings.py
+++ b/elos_be/settings.py
@@ -86,6 +86,7 @@ INSTALLED_APPS = [
     'eventos',
     'parceiros',
     'rede_social',
+    'usuarios',
     'doadores',
     'blog',
     'cadastro',


### PR DESCRIPTION
Este pr é parte da task #25

- adiciona testes unitários ao app `usuarios`
- 
# Como testar?

1. ative o environment com as libs contidas no `requirements.txt`;
2. configure as variáveis de ambiente;
3. Execute `python manage.py test apps`

<img width="584" alt="Screenshot 2022-11-19 at 21 44 17" src="https://user-images.githubusercontent.com/41929105/202877429-43db2e39-42eb-40b4-8a24-dac4468ddad2.png">

# Observação
Foi necessário rodar o comando:
`python manage.py migrate`

pois foi adicionado o app `usuarios` e é necessário aplicar o novo migration.

# Referência para essa solução:
[Django: Writing and running tests](https://docs.djangoproject.com/en/4.1/topics/testing/overview/)